### PR TITLE
Bypass Google's proxy when updating packages

### DIFF
--- a/ci/update-packages.ps1
+++ b/ci/update-packages.ps1
@@ -8,6 +8,7 @@ param (
 
 Push-Location $RepoName
 try {
+    $env:GOPROXY = "direct"
     go get -u ./... || $(throw "'go get -u' failed")
     go mod tidy || $(throw "'go mod tidy' failed")
 } finally {


### PR DESCRIPTION
Otherwise the new version of device-detection-go might not get noticed if the proxy hasn't polled the device-detection-go repo yet.