### PR TITLE
feat: Command line configuration

### DIFF
--- a/dd/example_base.go
+++ b/dd/example_base.go
@@ -69,7 +69,7 @@ func GetFilePathByPath(path string) string {
 		[]string{file},
 	)
 	if err != nil {
-		log.Fatalf("Could not find any file that matches for \"%s\" at path \"%s\".\n",
+		log.Fatalf("Could not find any file that matches \"%s\" at path \"%s\".\n",
 			file,
 			dir)
 	}
@@ -194,7 +194,7 @@ func ParseOptions() Options {
 	flag.StringVar(&options.DataFilePath, "d", options.DataFilePath, "Alias for -data-file")
 
 	flag.StringVar(&options.EvidenceFilePath, "user-agent-file", "../"+UaFile, "Path to a User-Agents CSV file")
-	flag.StringVar(&options.EvidenceFilePath, "u", options.DataFilePath, "Alias for -user-agent-file")
+	flag.StringVar(&options.EvidenceFilePath, "u", options.EvidenceFilePath, "Alias for -user-agent-file")
 
 	flag.StringVar(&options.LogOutputPath, "log-output", "", "Path to a output log file")
 	flag.StringVar(&options.LogOutputPath, "l", options.LogOutputPath, "Alias for -log-output")

--- a/dd/getting_started/getting_started.go
+++ b/dd/getting_started/getting_started.go
@@ -72,11 +72,11 @@ func match(
 	return returnStr
 }
 
-func runGettingStarted(perf dd.PerformanceProfile, options dd_example.Options) string {
+func runGettingStarted(perf dd.PerformanceProfile) string {
 	// Initialise manager
 	manager := dd.NewResourceManager()
 	config := dd.NewConfigHash(perf)
-	filePath := dd_example.GetFilePath(options.DataFilePath, []string{dd_example.LiteDataFile})
+	filePath := dd_example.GetFilePathByName([]string{dd_example.LiteDataFile})
 
 	err := dd.InitManagerFromFile(
 		manager,

--- a/dd/getting_started/getting_started.go
+++ b/dd/getting_started/getting_started.go
@@ -29,8 +29,9 @@ User-Agent strings.
 
 import (
 	"fmt"
-	dd_example "github.com/51Degrees/device-detection-examples-go/v4/dd"
 	"log"
+
+	dd_example "github.com/51Degrees/device-detection-examples-go/v4/dd"
 
 	"github.com/51Degrees/device-detection-go/v4/dd"
 )
@@ -71,11 +72,11 @@ func match(
 	return returnStr
 }
 
-func runGettingStarted(perf dd.PerformanceProfile) string {
+func runGettingStarted(perf dd.PerformanceProfile, options dd_example.Options) string {
 	// Initialise manager
 	manager := dd.NewResourceManager()
 	config := dd.NewConfigHash(perf)
-	filePath := dd_example.GetFilePath([]string{dd_example.LiteDataFile})
+	filePath := dd_example.GetFilePath(options.DataFilePath, []string{dd_example.LiteDataFile})
 
 	err := dd.InitManagerFromFile(
 		manager,

--- a/dd/match_device_id/match_device_id.go
+++ b/dd/match_device_id/match_device_id.go
@@ -29,8 +29,9 @@ package main
 
 import (
 	"fmt"
-	dd_example "github.com/51Degrees/device-detection-examples-go/v4/dd"
 	"log"
+
+	dd_example "github.com/51Degrees/device-detection-examples-go/v4/dd"
 
 	"github.com/51Degrees/device-detection-go/v4/dd"
 )
@@ -88,11 +89,11 @@ func matchDeviceId(
 	return returnStr
 }
 
-func runMatchDeviceId(perf dd.PerformanceProfile) string {
+func runMatchDeviceId(perf dd.PerformanceProfile, options dd_example.Options) string {
 	// Initialise manager
 	manager := dd.NewResourceManager()
 	config := dd.NewConfigHash(perf)
-	filePath := dd_example.GetFilePath([]string{dd_example.LiteDataFile})
+	filePath := dd_example.GetFilePath(options.DataFilePath, []string{dd_example.LiteDataFile})
 
 	err := dd.InitManagerFromFile(
 		manager,

--- a/dd/match_device_id/match_device_id.go
+++ b/dd/match_device_id/match_device_id.go
@@ -89,11 +89,11 @@ func matchDeviceId(
 	return returnStr
 }
 
-func runMatchDeviceId(perf dd.PerformanceProfile, options dd_example.Options) string {
+func runMatchDeviceId(perf dd.PerformanceProfile) string {
 	// Initialise manager
 	manager := dd.NewResourceManager()
 	config := dd.NewConfigHash(perf)
-	filePath := dd_example.GetFilePath(options.DataFilePath, []string{dd_example.LiteDataFile})
+	filePath := dd_example.GetFilePathByName([]string{dd_example.LiteDataFile})
 
 	err := dd.InitManagerFromFile(
 		manager,

--- a/dd/match_metrics/match_metrics.go
+++ b/dd/match_metrics/match_metrics.go
@@ -136,11 +136,11 @@ func verifyOutputFormat(matchReport string) string {
 // import "fmt"
 // import "github.com/51Degrees/device-detection-go/ddonpremise"
 
-func runMatchMetrics(perf dd.PerformanceProfile, options dd_example.Options) string {
+func runMatchMetrics(perf dd.PerformanceProfile) string {
 	// Initialise manager
 	manager := dd.NewResourceManager()
 	config := dd.NewConfigHash(perf)
-	filePath := dd_example.GetFilePath(options.DataFilePath, []string{dd_example.LiteDataFile})
+	filePath := dd_example.GetFilePathByName([]string{dd_example.LiteDataFile})
 
 	err := dd.InitManagerFromFile(
 		manager,

--- a/dd/match_metrics/match_metrics.go
+++ b/dd/match_metrics/match_metrics.go
@@ -28,9 +28,10 @@ This example illustrates how match metrics can be accessed.
 
 import (
 	"fmt"
-	dd_example "github.com/51Degrees/device-detection-examples-go/v4/dd"
 	"log"
 	"regexp"
+
+	dd_example "github.com/51Degrees/device-detection-examples-go/v4/dd"
 
 	"github.com/51Degrees/device-detection-go/v4/dd"
 )
@@ -135,11 +136,11 @@ func verifyOutputFormat(matchReport string) string {
 // import "fmt"
 // import "github.com/51Degrees/device-detection-go/ddonpremise"
 
-func runMatchMetrics(perf dd.PerformanceProfile) string {
+func runMatchMetrics(perf dd.PerformanceProfile, options dd_example.Options) string {
 	// Initialise manager
 	manager := dd.NewResourceManager()
 	config := dd.NewConfigHash(perf)
-	filePath := dd_example.GetFilePath([]string{dd_example.LiteDataFile})
+	filePath := dd_example.GetFilePath(options.DataFilePath, []string{dd_example.LiteDataFile})
 
 	err := dd.InitManagerFromFile(
 		manager,

--- a/dd/offline_processing/offline_processing.go
+++ b/dd/offline_processing/offline_processing.go
@@ -45,12 +45,13 @@ available properties for each User-Agent.
 import (
 	"bufio"
 	"fmt"
-	dd_example "github.com/51Degrees/device-detection-examples-go/v4/dd"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
+
+	dd_example "github.com/51Degrees/device-detection-examples-go/v4/dd"
 
 	"github.com/51Degrees/device-detection-go/v4/dd"
 )
@@ -162,12 +163,12 @@ func process(
 	}
 }
 
-func runOfflineProcessing(perf dd.PerformanceProfile) string {
+func runOfflineProcessing(perf dd.PerformanceProfile, options dd_example.Options) string {
 	// Initialise manager
 	manager := dd.NewResourceManager()
 	config := dd.NewConfigHash(perf)
-	filePath := dd_example.GetFilePath([]string{dd_example.LiteDataFile})
-	uaFilePath := dd_example.GetFilePath([]string{dd_example.UaFile})
+	filePath := dd_example.GetFilePath(options.DataFilePath, []string{dd_example.LiteDataFile})
+	uaFilePath := dd_example.GetFilePath(options.EvidenceFilePath, []string{dd_example.UaFile})
 	uaDir := filepath.Dir(uaFilePath)
 	uaBase := strings.TrimSuffix(filepath.Base(uaFilePath), filepath.Ext(uaFilePath))
 	outputFilePath := fmt.Sprintf("%s/%s.processed.csv", uaDir, uaBase)

--- a/dd/offline_processing/offline_processing.go
+++ b/dd/offline_processing/offline_processing.go
@@ -163,12 +163,12 @@ func process(
 	}
 }
 
-func runOfflineProcessing(perf dd.PerformanceProfile, options dd_example.Options) string {
+func runOfflineProcessing(perf dd.PerformanceProfile) string {
 	// Initialise manager
 	manager := dd.NewResourceManager()
 	config := dd.NewConfigHash(perf)
-	filePath := dd_example.GetFilePath(options.DataFilePath, []string{dd_example.LiteDataFile})
-	uaFilePath := dd_example.GetFilePath(options.EvidenceFilePath, []string{dd_example.UaFile})
+	filePath := dd_example.GetFilePathByName([]string{dd_example.LiteDataFile})
+	uaFilePath := dd_example.GetFilePathByName([]string{dd_example.UaFile})
 	uaDir := filepath.Dir(uaFilePath)
 	uaBase := strings.TrimSuffix(filepath.Base(uaFilePath), filepath.Ext(uaFilePath))
 	outputFilePath := fmt.Sprintf("%s/%s.processed.csv", uaDir, uaBase)

--- a/dd/performance/performance.go
+++ b/dd/performance/performance.go
@@ -120,7 +120,7 @@ func performDetections(
 	rep *report) {
 	// Create a wait group
 	var wg sync.WaitGroup
-	uaFilePath := dd_example.GetFilePath(options.EvidenceFilePath, []string{dd_example.UaFile})
+	uaFilePath := dd_example.GetFilePathByPath(options.EvidenceFilePath)
 
 	rep.uaCount = dd_example.CountUAFromFiles(uaFilePath)
 	rep.uaCount *= options.Iterations
@@ -253,7 +253,7 @@ func run(
 // Setup all configuration settings required for running this example.
 // Run the example.
 func runPerformance(perf dd.PerformanceProfile, options dd_example.Options) string {
-	dataFilePath := dd_example.GetFilePath(options.DataFilePath, []string{dd_example.LiteDataFile})
+	dataFilePath := dd_example.GetFilePathByPath(options.DataFilePath)
 
 	// Create Resource Manager
 	manager := dd.NewResourceManager()
@@ -280,7 +280,7 @@ func runPerformance(perf dd.PerformanceProfile, options dd_example.Options) stri
 }
 
 func main() {
-	dd_example.PerformExample(dd.InMemory, runPerformance)
+	dd_example.PerformExampleOptions(dd.InMemory, runPerformance)
 	// The performance is output to a file 'performance_report.log' with content
 	// similar as below:
 	//   Average 0.01510 ms per User-Agent

--- a/dd/reload_from_file/reload_from_file.go
+++ b/dd/reload_from_file/reload_from_file.go
@@ -28,7 +28,6 @@ Illustrates how dataset can be reloaded while detections are performed.
 
 import (
 	"bufio"
-	dd_example "github.com/51Degrees/device-detection-examples-go/v4/dd"
 	"hash/fnv"
 	"log"
 	"os"
@@ -36,6 +35,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	dd_example "github.com/51Degrees/device-detection-examples-go/v4/dd"
 
 	"github.com/51Degrees/device-detection-go/v4/dd"
 )
@@ -195,9 +196,9 @@ func runReloadFromFileSub(
 	return "Program execution complete."
 }
 
-func runReloadFromFile(perf dd.PerformanceProfile) string {
-	dataFilePath := dd_example.GetFilePath([]string{dd_example.LiteDataFile})
-	uaFilePath := dd_example.GetFilePath([]string{dd_example.UaFile})
+func runReloadFromFile(perf dd.PerformanceProfile, options dd_example.Options) string {
+	dataFilePath := dd_example.GetFilePath(options.DataFilePath, []string{dd_example.LiteDataFile})
+	uaFilePath := dd_example.GetFilePath(options.EvidenceFilePath, []string{dd_example.UaFile})
 
 	// Create Resource Manager
 	manager := dd.NewResourceManager()

--- a/dd/reload_from_file/reload_from_file.go
+++ b/dd/reload_from_file/reload_from_file.go
@@ -196,9 +196,9 @@ func runReloadFromFileSub(
 	return "Program execution complete."
 }
 
-func runReloadFromFile(perf dd.PerformanceProfile, options dd_example.Options) string {
-	dataFilePath := dd_example.GetFilePath(options.DataFilePath, []string{dd_example.LiteDataFile})
-	uaFilePath := dd_example.GetFilePath(options.EvidenceFilePath, []string{dd_example.UaFile})
+func runReloadFromFile(perf dd.PerformanceProfile) string {
+	dataFilePath := dd_example.GetFilePathByName([]string{dd_example.LiteDataFile})
+	uaFilePath := dd_example.GetFilePathByName([]string{dd_example.UaFile})
 
 	// Create Resource Manager
 	manager := dd.NewResourceManager()


### PR DESCRIPTION
Feature described in https://github.com/51Degrees/device-detection-examples-go/issues/20

> The Go performance example does [not enable](https://github.com/51Degrees/device-detection-examples-go/blob/c9a8d8f3c2397c130a02f6658a893f4862c20779/dd/performance/performance.go#L257) the settings and data files to be provided via the command line.

> See the [C example](https://github.com/51Degrees/device-detection-cxx/blob/630361aba14a773dac7ee4d9309217714b2e5541/examples/C/Hash/Performance.c#L639) as the template.