### PR TITLE
Feat/yaml migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pwsh ci/fetch-assets.ps1 .
 or alternatively you can download them from [device-detection-data](https://github.com/51Degrees/device-detection-data) repo (the links are below) and put in the root of this repository. 
 
 - [51Degrees-LiteV4.1.hash](https://github.com/51Degrees/device-detection-data/blob/main/51Degrees-LiteV4.1.hash)
-- [20000 User Agents.csv](https://github.com/51Degrees/device-detection-data/blob/main/20000%20User%20Agents.csv)
+- [20000 Evidence Records.yml](https://github.com/51Degrees/device-detection-data/blob/main/20000%20Evidence%20Records.yml)
 
 ## Examples
 
@@ -32,7 +32,7 @@ Below is a table that describes the examples:
 |dd/getting_started/getting_sarted.go|A simple example that shows how to initialize a resource manager and perform device detection on User-Agent strings.|
 |dd/match_device_id/match_device_id.go|A simple example that shows how to perform device detection using Device Id.|
 |dd/match_metrics/match_metrics.go|A simple example that shows how to access match metrics.|
-|dd/offline_processing/offline_processing.go|An example that shows how to process through User-Agents stored in a file, and output detection results and metrics to a local file for further evaluation. Output file is `./device-detection-go/dd/device-detection-cxx/device-detection-data/20000 User Agents.processed.csv`|
+|dd/offline_processing/offline_processing.go|An example that shows how to process through User-Agents stored in a file, and output detection results and metrics to a local file for further evaluation. Output file is `./device-detection-go/dd/device-detection-cxx/device-detection-data/20000 Evidence Records.yml`|
 |dd/performance/performance.go|An example perform performance benchmarking of our device detection solution and output the benchmark to a report file. Output file is `performance_report.log` in the working directory.|
 |dd/reload_from_file/reload_from_file.go|An example that demonstrates how a data file can be reloaded while serving device detection requests.|
 |dd/reload_from_memory/reload_from_memory.go|To be implemented|

--- a/ci/fetch-assets.ps1
+++ b/ci/fetch-assets.ps1
@@ -10,6 +10,7 @@ $file = "51Degrees-LiteV4.1.hash"
 $downloads = @{
     "51Degrees-LiteV4.1.hash" = {Invoke-WebRequest -Uri "https://github.com/51Degrees/device-detection-data/raw/main/51Degrees-LiteV4.1.hash" -OutFile $assets/$file}
     "20000 User Agents.csv" = {Invoke-WebRequest -Uri "https://media.githubusercontent.com/media/51Degrees/device-detection-data/main/20000%20User%20Agents.csv" -OutFile $assets/$file}
+    "20000 Evidence Records.yml" = {Invoke-WebRequest -Uri "https://media.githubusercontent.com/media/51Degrees/device-detection-data/main/20000%20Evidence%20Records.yml" -OutFile $assets/$file}
 }
 
 foreach ($file in $downloads.Keys) {
@@ -23,3 +24,4 @@ foreach ($file in $downloads.Keys) {
 
 New-Item -ItemType SymbolicLink -Force -Target "$assets/51Degrees-LiteV4.1.hash" -Path "$assetsDestination/51Degrees-LiteV4.1.hash"
 New-Item -ItemType SymbolicLink -Force -Target "$assets/20000 User Agents.csv" -Path "$assetsDestination/20000 User Agents.csv"
+New-Item -ItemType SymbolicLink -Force -Target "$assets/20000 Evidence Records.yml" -Path "$assetsDestination/20000 Evidence Records.yml"

--- a/dd/example_base.go
+++ b/dd/example_base.go
@@ -44,8 +44,8 @@ import (
 // Constants
 const LiteDataFile = "51Degrees-LiteV4.1.hash"
 const EnterpriseDataFile = "Enterprise-HashV41.hash"
-const UaFile = "20000 User Agents.csv"
-const EvidenceFile = "20000 Evidence Records.yml"
+const UaFileCSV = "20000 User Agents.csv"
+const EvidenceFileYaml = "20000 Evidence Records.yml"
 
 // Evidence where all fields are in string format
 type stringEvidence struct {
@@ -262,7 +262,7 @@ func ParseOptions() Options {
 	flag.StringVar(&options.DataFilePath, "data-file", "../"+LiteDataFile, "Path to a 51Degrees Hash data file")
 	flag.StringVar(&options.DataFilePath, "d", options.DataFilePath, "Alias for -data-file")
 
-	flag.StringVar(&options.EvidenceFilePath, "evidence-file", "../"+EvidenceFile, "Path to a Evidence Records YAML file")
+	flag.StringVar(&options.EvidenceFilePath, "evidence-file", "../"+EvidenceFileYaml, "Path to a Evidence Records YAML file")
 	flag.StringVar(&options.EvidenceFilePath, "e", options.EvidenceFilePath, "Alias for -evidence-file")
 
 	flag.StringVar(&options.LogOutputPath, "log-output", "", "Path to a output log file")

--- a/dd/example_base.go
+++ b/dd/example_base.go
@@ -69,7 +69,7 @@ func GetFilePathByPath(path string) string {
 		[]string{file},
 	)
 	if err != nil {
-		log.Fatalf("Could not find any file that matches for \"%s\" at path \"%s\".\n",
+		log.Fatalf("Could not find any file that matches \"%s\" at path \"%s\".\n",
 			file,
 			dir)
 	}
@@ -194,7 +194,7 @@ func ParseOptions() Options {
 	flag.StringVar(&options.DataFilePath, "d", options.DataFilePath, "Alias for -data-file")
 
 	flag.StringVar(&options.EvidenceFilePath, "user-agent-file", "../"+UaFile, "Path to a User-Agents CSV file")
-	flag.StringVar(&options.EvidenceFilePath, "u", options.DataFilePath, "Alias for -user-agent-file")
+	flag.StringVar(&options.EvidenceFilePath, "u", options.EvidenceFilePath, "Alias for -user-agent-file")
 
 	flag.StringVar(&options.LogOutputPath, "log-output", "", "Path to a output log file")
 	flag.StringVar(&options.LogOutputPath, "l", options.LogOutputPath, "Alias for -log-output")

--- a/dd/getting_started/getting_started.go
+++ b/dd/getting_started/getting_started.go
@@ -72,11 +72,11 @@ func match(
 	return returnStr
 }
 
-func runGettingStarted(perf dd.PerformanceProfile, options dd_example.Options) string {
+func runGettingStarted(perf dd.PerformanceProfile) string {
 	// Initialise manager
 	manager := dd.NewResourceManager()
 	config := dd.NewConfigHash(perf)
-	filePath := dd_example.GetFilePath(options.DataFilePath, []string{dd_example.LiteDataFile})
+	filePath := dd_example.GetFilePathByName([]string{dd_example.LiteDataFile})
 
 	err := dd.InitManagerFromFile(
 		manager,

--- a/dd/getting_started/getting_started.go
+++ b/dd/getting_started/getting_started.go
@@ -29,8 +29,9 @@ User-Agent strings.
 
 import (
 	"fmt"
-	dd_example "github.com/51Degrees/device-detection-examples-go/v4/dd"
 	"log"
+
+	dd_example "github.com/51Degrees/device-detection-examples-go/v4/dd"
 
 	"github.com/51Degrees/device-detection-go/v4/dd"
 )
@@ -71,11 +72,11 @@ func match(
 	return returnStr
 }
 
-func runGettingStarted(perf dd.PerformanceProfile) string {
+func runGettingStarted(perf dd.PerformanceProfile, options dd_example.Options) string {
 	// Initialise manager
 	manager := dd.NewResourceManager()
 	config := dd.NewConfigHash(perf)
-	filePath := dd_example.GetFilePath([]string{dd_example.LiteDataFile})
+	filePath := dd_example.GetFilePath(options.DataFilePath, []string{dd_example.LiteDataFile})
 
 	err := dd.InitManagerFromFile(
 		manager,

--- a/dd/match_device_id/match_device_id.go
+++ b/dd/match_device_id/match_device_id.go
@@ -29,8 +29,9 @@ package main
 
 import (
 	"fmt"
-	dd_example "github.com/51Degrees/device-detection-examples-go/v4/dd"
 	"log"
+
+	dd_example "github.com/51Degrees/device-detection-examples-go/v4/dd"
 
 	"github.com/51Degrees/device-detection-go/v4/dd"
 )
@@ -88,11 +89,11 @@ func matchDeviceId(
 	return returnStr
 }
 
-func runMatchDeviceId(perf dd.PerformanceProfile) string {
+func runMatchDeviceId(perf dd.PerformanceProfile, options dd_example.Options) string {
 	// Initialise manager
 	manager := dd.NewResourceManager()
 	config := dd.NewConfigHash(perf)
-	filePath := dd_example.GetFilePath([]string{dd_example.LiteDataFile})
+	filePath := dd_example.GetFilePath(options.DataFilePath, []string{dd_example.LiteDataFile})
 
 	err := dd.InitManagerFromFile(
 		manager,

--- a/dd/match_device_id/match_device_id.go
+++ b/dd/match_device_id/match_device_id.go
@@ -89,11 +89,11 @@ func matchDeviceId(
 	return returnStr
 }
 
-func runMatchDeviceId(perf dd.PerformanceProfile, options dd_example.Options) string {
+func runMatchDeviceId(perf dd.PerformanceProfile) string {
 	// Initialise manager
 	manager := dd.NewResourceManager()
 	config := dd.NewConfigHash(perf)
-	filePath := dd_example.GetFilePath(options.DataFilePath, []string{dd_example.LiteDataFile})
+	filePath := dd_example.GetFilePathByName([]string{dd_example.LiteDataFile})
 
 	err := dd.InitManagerFromFile(
 		manager,

--- a/dd/match_metrics/match_metrics.go
+++ b/dd/match_metrics/match_metrics.go
@@ -136,11 +136,11 @@ func verifyOutputFormat(matchReport string) string {
 // import "fmt"
 // import "github.com/51Degrees/device-detection-go/ddonpremise"
 
-func runMatchMetrics(perf dd.PerformanceProfile, options dd_example.Options) string {
+func runMatchMetrics(perf dd.PerformanceProfile) string {
 	// Initialise manager
 	manager := dd.NewResourceManager()
 	config := dd.NewConfigHash(perf)
-	filePath := dd_example.GetFilePath(options.DataFilePath, []string{dd_example.LiteDataFile})
+	filePath := dd_example.GetFilePathByName([]string{dd_example.LiteDataFile})
 
 	err := dd.InitManagerFromFile(
 		manager,

--- a/dd/match_metrics/match_metrics.go
+++ b/dd/match_metrics/match_metrics.go
@@ -28,9 +28,10 @@ This example illustrates how match metrics can be accessed.
 
 import (
 	"fmt"
-	dd_example "github.com/51Degrees/device-detection-examples-go/v4/dd"
 	"log"
 	"regexp"
+
+	dd_example "github.com/51Degrees/device-detection-examples-go/v4/dd"
 
 	"github.com/51Degrees/device-detection-go/v4/dd"
 )
@@ -135,11 +136,11 @@ func verifyOutputFormat(matchReport string) string {
 // import "fmt"
 // import "github.com/51Degrees/device-detection-go/ddonpremise"
 
-func runMatchMetrics(perf dd.PerformanceProfile) string {
+func runMatchMetrics(perf dd.PerformanceProfile, options dd_example.Options) string {
 	// Initialise manager
 	manager := dd.NewResourceManager()
 	config := dd.NewConfigHash(perf)
-	filePath := dd_example.GetFilePath([]string{dd_example.LiteDataFile})
+	filePath := dd_example.GetFilePath(options.DataFilePath, []string{dd_example.LiteDataFile})
 
 	err := dd.InitManagerFromFile(
 		manager,

--- a/dd/offline_processing/offline_processing.go
+++ b/dd/offline_processing/offline_processing.go
@@ -159,7 +159,7 @@ func runOfflineProcessing(perf dd.PerformanceProfile) string {
 	manager := dd.NewResourceManager()
 	config := dd.NewConfigHash(perf)
 	filePath := dd_example.GetFilePathByName([]string{dd_example.LiteDataFile})
-	evidenceFilePath := dd_example.GetFilePathByName([]string{dd_example.EvidenceFile})
+	evidenceFilePath := dd_example.GetFilePathByName([]string{dd_example.EvidenceFileYaml})
 	evDir := filepath.Dir(evidenceFilePath)
 	evBase := strings.TrimSuffix(filepath.Base(evidenceFilePath), filepath.Ext(evidenceFilePath))
 	outputFilePath := fmt.Sprintf("%s/%s.processed.yml", evDir, evBase)
@@ -196,5 +196,5 @@ func runOfflineProcessing(perf dd.PerformanceProfile) string {
 func main() {
 	dd_example.PerformExample(dd.Default, runOfflineProcessing)
 	// Output:
-	// Output to "../20000 Evidence Records.processed.csv".
+	// Output to "../20000 Evidence Records.processed.yml".
 }

--- a/dd/offline_processing/offline_processing.go
+++ b/dd/offline_processing/offline_processing.go
@@ -23,8 +23,8 @@
 package main
 
 /*
-This example illustrates how to process a list of User-Agents from file and
-output detection metrics and properties of each User-Agent to another file for
+This example illustrates how to process a list of Evidence Records from file and
+output detection metrics and properties of each Evidence Record to another file for
 further evaluation.
 
 Expected output is as described at the "// Output:..." section locate at the
@@ -36,14 +36,11 @@ go test -run Example_offline_processing
 ```
 
 This example will output to a file located at
-"../device-detection-go/dd/device-detection-cxx/device-detection-data/20000 User Agents.processed.csv".
-This contains the detection metrics User-Agent,Drift,Difference,Iterations and
-available properties for each User-Agent.
-
+"../device-detection-go/dd/device-detection-cxx/device-detection-data/20000 Evidence Records.processed.yml".
+This contains IsMobile, BrowserName, BrowserVersion, PlatformName, PlatformVersion, DeviceId
 */
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"log"
@@ -52,114 +49,108 @@ import (
 	"strings"
 
 	dd_example "github.com/51Degrees/device-detection-examples-go/v4/dd"
+	"gopkg.in/yaml.v3"
 
 	"github.com/51Degrees/device-detection-go/v4/dd"
 )
 
-// function match performs a match on an input User-Agent string and determine
-// if the device is a mobile device.
-func processUserAgent(
-	results *dd.ResultsHash,
-	ua string) {
+// function match performs a match on an input Evidence, calulates
+// configured properties and returns them as yaml entry
+func processEvidence(
+	manager *dd.ResourceManager,
+	evidence *dd.Evidence) map[string]string {
+	defer evidence.Free()
+	// Create results
+	results := dd.NewResultsHash(manager, uint32(evidence.Count()), 0)
+	// Make sure results object is freed after function execution.
+	defer results.Free()
+	available := results.AvailableProperties()
+
 	// Perform detection
-	err := results.MatchUserAgent(ua)
+	err := results.MatchEvidence(evidence)
 	if err != nil {
-		log.Fatalf(
-			"ERROR: \"%s\" on User-Agent \"%s\".\n", err, ua)
+		log.Fatal("ERROR: Failed to perform detection.")
 	}
+
+	// Get the values in string
+	res := make(map[string]string)
+	for i := 0; i < len(available); i++ {
+		hasValues, err := results.HasValuesByIndex(i)
+		if err != nil {
+			log.Fatalln(err)
+		}
+
+		lowerKey := strings.ToLower(available[i])
+		if hasValues {
+			value, err := results.ValuesString(
+				available[i],
+				",")
+			if err != nil {
+				log.Fatalln(err)
+			}
+			res["device."+lowerKey] = value
+		}
+	}
+	res["device.deviceid"], err = results.DeviceId()
+	if err != nil {
+		log.Fatalf("ERROR: Failed to get unique DeviceID: %v", err)
+	}
+	return res
 }
 
 func process(
 	manager *dd.ResourceManager,
-	uaFilePath string,
+	evidenceFilePath string,
 	outputFilePath string) {
 	outFile, err := os.Create(outputFilePath)
 	if err != nil {
 		log.Fatalf("ERROR: Failed to create file %s.\n", outputFilePath)
 	}
-
-	// Create results
-	results := dd.NewResultsHash(manager, 1, 0)
-
-	// Make sure results object is freed after function execution.
-	defer results.Free()
-
-	// Open the User-Agents file for processing
-	uaFile, err := os.OpenFile(uaFilePath, os.O_RDONLY, 0444)
-	if err != nil {
-		log.Fatalf("ERROR: Failed to open file \"%s\".\n", uaFilePath)
-	}
-
-	// Create a scanner to read User-Agents
-	scanner := bufio.NewScanner(uaFile)
 	defer func() {
-		if err := scanner.Err(); err != nil {
-			log.Fatalf("ERROR: Failed during scanning file \"%s\".\n", uaFilePath)
+		if err := outFile.Close(); err != nil {
+			log.Fatalf("ERROR: Failed to close file \"%s\".\n", outputFilePath)
 		}
 	}()
 
-	w := io.Writer(outFile)
-	available := results.AvailableProperties()
-
-	// Print header to output file
-	fmt.Fprintf(w, "\"User-Agent\",\"Drift\",\"Difference\",\"Iterations\"")
-	for i := 0; i < len(available); i++ {
-		fmt.Fprintf(w, ",\"%s\"", available[i])
+	// Open the Evidence Records file for processing
+	file, err := os.OpenFile(evidenceFilePath, os.O_RDONLY, 0444)
+	if err != nil {
+		log.Fatalf("ERROR: Failed to open file \"%s\".\n", evidenceFilePath)
 	}
-	fmt.Fprintf(w, "\n")
+	defer func() {
+		if err := file.Close(); err != nil {
+			log.Fatalf("ERROR: Failed to close file \"%s\".\n", evidenceFilePath)
+		}
+	}()
 
-	for scanner.Scan() {
-		processUserAgent(results, scanner.Text())
-		// Output the matched  user agent string, drift, difference, iterations
-		userAgent, err := results.UserAgent(0)
+	enc := yaml.NewEncoder(outFile)
+	dec := yaml.NewDecoder(file)
+	for {
+		// Decode Evidence file by line
+		var doc map[string]string
+		if err := dec.Decode(&doc); err == io.EOF {
+			break
+		} else if err != nil {
+			log.Fatalf("ERROR: Failed during decoding file \"%s\". %v\n", evidenceFilePath, err)
+		}
+
+		// Prepare evidence for usage
+		filteredEvidence := dd_example.ConvertEvidenceMap(doc)
+		evidence := dd_example.ExtractEvidence(filteredEvidence)
+
+		values := processEvidence(manager, evidence)
+
+		err = enc.Encode(values)
 		if err != nil {
-			log.Fatal(err.Error())
+			log.Fatalf("ERROR: Failed during encoding file \"%s\". %v\n", outputFilePath, err)
 		}
+	}
+	enc.Close()
 
-		drift, err := results.DriftByIndex(0)
-		if err != nil {
-			log.Fatal(err.Error())
-		}
-
-		difference, err := results.DifferenceByIndex(0)
-		if err != nil {
-			log.Fatal(err.Error())
-		}
-
-		iterations, err := results.IterationsByIndex(0)
-		if err != nil {
-			log.Fatal(err.Error())
-		}
-
-		fmt.Fprintf(
-			w,
-			"\"%s\",%d,%d,%d",
-			userAgent,
-			drift,
-			difference,
-			iterations)
-		// Get the values in string
-		for i := 0; i < len(available); i++ {
-			hasValues, err := results.HasValuesByIndex(i)
-			if err != nil {
-				log.Fatalln(err)
-			}
-
-			// Write empty value if one isn't available
-			if !hasValues {
-				fmt.Fprintf(w, ",\"\"")
-			} else {
-				value, err := results.ValuesString(
-					"IsMobile",
-					",")
-				if err != nil {
-					log.Fatalln(err)
-				}
-
-				fmt.Fprintf(w, ",%s", value)
-			}
-		}
-		fmt.Fprintf(w, "\n")
+	// Manually writing '...' to end the YAML file
+	_, err = outFile.WriteString("...\n")
+	if err != nil {
+		log.Fatalf("ERROR: Failed to write end for file \"%s\". %v\n", outputFilePath, err)
 	}
 }
 
@@ -168,10 +159,10 @@ func runOfflineProcessing(perf dd.PerformanceProfile) string {
 	manager := dd.NewResourceManager()
 	config := dd.NewConfigHash(perf)
 	filePath := dd_example.GetFilePathByName([]string{dd_example.LiteDataFile})
-	uaFilePath := dd_example.GetFilePathByName([]string{dd_example.UaFile})
-	uaDir := filepath.Dir(uaFilePath)
-	uaBase := strings.TrimSuffix(filepath.Base(uaFilePath), filepath.Ext(uaFilePath))
-	outputFilePath := fmt.Sprintf("%s/%s.processed.csv", uaDir, uaBase)
+	evidenceFilePath := dd_example.GetFilePathByName([]string{dd_example.EvidenceFile})
+	evDir := filepath.Dir(evidenceFilePath)
+	evBase := strings.TrimSuffix(filepath.Base(evidenceFilePath), filepath.Ext(evidenceFilePath))
+	outputFilePath := fmt.Sprintf("%s/%s.processed.yml", evDir, evBase)
 	// Get base path
 	basePath, err := os.Getwd()
 	if err != nil {
@@ -189,7 +180,7 @@ func runOfflineProcessing(perf dd.PerformanceProfile) string {
 	err = dd.InitManagerFromFile(
 		manager,
 		*config,
-		"IsMobile,BrowserName,DeviceType,PriceBand,ReleaseMonth,ReleaseYear",
+		"IsMobile,BrowserName,BrowserVersion,PlatformName,PlatformVersion",
 		filePath)
 	if err != nil {
 		log.Fatalln(err)
@@ -198,12 +189,12 @@ func runOfflineProcessing(perf dd.PerformanceProfile) string {
 	// Make sure manager object will be freed after the function execution
 	defer manager.Free()
 
-	process(manager, uaFilePath, outputFilePath)
+	process(manager, evidenceFilePath, outputFilePath)
 	return fmt.Sprintf("Output to \"%s\".\n", relOutputFilePath)
 }
 
 func main() {
 	dd_example.PerformExample(dd.Default, runOfflineProcessing)
 	// Output:
-	// Output to "../20000 User Agents.processed.csv".
+	// Output to "../20000 Evidence Records.processed.csv".
 }

--- a/dd/offline_processing/offline_processing.go
+++ b/dd/offline_processing/offline_processing.go
@@ -45,12 +45,13 @@ available properties for each User-Agent.
 import (
 	"bufio"
 	"fmt"
-	dd_example "github.com/51Degrees/device-detection-examples-go/v4/dd"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
+
+	dd_example "github.com/51Degrees/device-detection-examples-go/v4/dd"
 
 	"github.com/51Degrees/device-detection-go/v4/dd"
 )
@@ -162,12 +163,12 @@ func process(
 	}
 }
 
-func runOfflineProcessing(perf dd.PerformanceProfile) string {
+func runOfflineProcessing(perf dd.PerformanceProfile, options dd_example.Options) string {
 	// Initialise manager
 	manager := dd.NewResourceManager()
 	config := dd.NewConfigHash(perf)
-	filePath := dd_example.GetFilePath([]string{dd_example.LiteDataFile})
-	uaFilePath := dd_example.GetFilePath([]string{dd_example.UaFile})
+	filePath := dd_example.GetFilePath(options.DataFilePath, []string{dd_example.LiteDataFile})
+	uaFilePath := dd_example.GetFilePath(options.EvidenceFilePath, []string{dd_example.UaFile})
 	uaDir := filepath.Dir(uaFilePath)
 	uaBase := strings.TrimSuffix(filepath.Base(uaFilePath), filepath.Ext(uaFilePath))
 	outputFilePath := fmt.Sprintf("%s/%s.processed.csv", uaDir, uaBase)

--- a/dd/offline_processing/offline_processing.go
+++ b/dd/offline_processing/offline_processing.go
@@ -163,12 +163,12 @@ func process(
 	}
 }
 
-func runOfflineProcessing(perf dd.PerformanceProfile, options dd_example.Options) string {
+func runOfflineProcessing(perf dd.PerformanceProfile) string {
 	// Initialise manager
 	manager := dd.NewResourceManager()
 	config := dd.NewConfigHash(perf)
-	filePath := dd_example.GetFilePath(options.DataFilePath, []string{dd_example.LiteDataFile})
-	uaFilePath := dd_example.GetFilePath(options.EvidenceFilePath, []string{dd_example.UaFile})
+	filePath := dd_example.GetFilePathByName([]string{dd_example.LiteDataFile})
+	uaFilePath := dd_example.GetFilePathByName([]string{dd_example.UaFile})
 	uaDir := filepath.Dir(uaFilePath)
 	uaBase := strings.TrimSuffix(filepath.Base(uaFilePath), filepath.Ext(uaFilePath))
 	outputFilePath := fmt.Sprintf("%s/%s.processed.csv", uaDir, uaBase)

--- a/dd/performance/performance.go
+++ b/dd/performance/performance.go
@@ -120,7 +120,7 @@ func performDetections(
 	rep *report) {
 	// Create a wait group
 	var wg sync.WaitGroup
-	uaFilePath := dd_example.GetFilePath(options.EvidenceFilePath, []string{dd_example.UaFile})
+	uaFilePath := dd_example.GetFilePathByPath(options.EvidenceFilePath)
 
 	rep.uaCount = dd_example.CountUAFromFiles(uaFilePath)
 	rep.uaCount *= options.Iterations
@@ -253,7 +253,7 @@ func run(
 // Setup all configuration settings required for running this example.
 // Run the example.
 func runPerformance(perf dd.PerformanceProfile, options dd_example.Options) string {
-	dataFilePath := dd_example.GetFilePath(options.DataFilePath, []string{dd_example.LiteDataFile})
+	dataFilePath := dd_example.GetFilePathByPath(options.DataFilePath)
 
 	// Create Resource Manager
 	manager := dd.NewResourceManager()
@@ -280,7 +280,7 @@ func runPerformance(perf dd.PerformanceProfile, options dd_example.Options) stri
 }
 
 func main() {
-	dd_example.PerformExample(dd.InMemory, runPerformance)
+	dd_example.PerformExampleOptions(dd.InMemory, runPerformance)
 	// The performance is output to a file 'performance_report.log' with content
 	// similar as below:
 	//   Average 0.01510 ms per User-Agent

--- a/dd/reload_from_file/reload_from_file.go
+++ b/dd/reload_from_file/reload_from_file.go
@@ -28,7 +28,6 @@ Illustrates how dataset can be reloaded while detections are performed.
 
 import (
 	"bufio"
-	dd_example "github.com/51Degrees/device-detection-examples-go/v4/dd"
 	"hash/fnv"
 	"log"
 	"os"
@@ -36,6 +35,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	dd_example "github.com/51Degrees/device-detection-examples-go/v4/dd"
 
 	"github.com/51Degrees/device-detection-go/v4/dd"
 )
@@ -195,9 +196,9 @@ func runReloadFromFileSub(
 	return "Program execution complete."
 }
 
-func runReloadFromFile(perf dd.PerformanceProfile) string {
-	dataFilePath := dd_example.GetFilePath([]string{dd_example.LiteDataFile})
-	uaFilePath := dd_example.GetFilePath([]string{dd_example.UaFile})
+func runReloadFromFile(perf dd.PerformanceProfile, options dd_example.Options) string {
+	dataFilePath := dd_example.GetFilePath(options.DataFilePath, []string{dd_example.LiteDataFile})
+	uaFilePath := dd_example.GetFilePath(options.EvidenceFilePath, []string{dd_example.UaFile})
 
 	// Create Resource Manager
 	manager := dd.NewResourceManager()

--- a/dd/reload_from_file/reload_from_file.go
+++ b/dd/reload_from_file/reload_from_file.go
@@ -196,9 +196,9 @@ func runReloadFromFileSub(
 	return "Program execution complete."
 }
 
-func runReloadFromFile(perf dd.PerformanceProfile, options dd_example.Options) string {
-	dataFilePath := dd_example.GetFilePath(options.DataFilePath, []string{dd_example.LiteDataFile})
-	uaFilePath := dd_example.GetFilePath(options.EvidenceFilePath, []string{dd_example.UaFile})
+func runReloadFromFile(perf dd.PerformanceProfile) string {
+	dataFilePath := dd_example.GetFilePathByName([]string{dd_example.LiteDataFile})
+	uaFilePath := dd_example.GetFilePathByName([]string{dd_example.UaFile})
 
 	// Create Resource Manager
 	manager := dd.NewResourceManager()

--- a/dd/reload_from_file/reload_from_file.go
+++ b/dd/reload_from_file/reload_from_file.go
@@ -213,7 +213,7 @@ func runReloadFromFileSub(
 
 func runReloadFromFile(perf dd.PerformanceProfile) string {
 	dataFilePath := dd_example.GetFilePathByName([]string{dd_example.LiteDataFile})
-	evidenceFilePath := dd_example.GetFilePathByName([]string{dd_example.EvidenceFile})
+	evidenceFilePath := dd_example.GetFilePathByName([]string{dd_example.EvidenceFileYaml})
 	// Create Resource Manager
 	manager := dd.NewResourceManager()
 	config := dd.NewConfigHash(dd.InMemory)

--- a/dd/reload_from_file/reload_from_file.go
+++ b/dd/reload_from_file/reload_from_file.go
@@ -77,7 +77,7 @@ func executeTest(
 	iteration uint32) {
 	defer evidence.Free()
 	// Create results
-	results := dd.NewResultsHash(manager, 1, 0)
+	results := dd.NewResultsHash(manager, uint32(evidence.Count()), 0)
 
 	// Make sure results object is freed after function execution.
 	defer results.Free()

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/51Degrees/device-detection-examples-go/v4
 
 go 1.20
 
-require github.com/51Degrees/device-detection-go/v4 v4.4.18
+require (
+	github.com/51Degrees/device-detection-go/v4 v4.4.18
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,7 @@
 github.com/51Degrees/device-detection-go/v4 v4.4.18 h1:T7aFtH060BBpDpnKqVxFRGaYkzG4YjMaDF0Ufgo1l+Y=
 github.com/51Degrees/device-detection-go/v4 v4.4.18/go.mod h1:T4ReXO9sGjoGJKct7L8GCfJwoPQkDv3EeIN3NpB27+8=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Feature described in https://github.com/51Degrees/device-detection-examples-go/issues/19

> Other examples have been migrated to use to the UACH and UA [yaml format evidence files]([20000 Evidence Records.yml](https://github.com/51Degrees/device-detection-data/blob/main/20000%20Evidence%20Records.yml)) contained in device-detection-data.

> Go needs to be modified to use the same concepts to ensure UA and UACH data is included.