### PR TITLE
Updated README section for running on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@ or alternatively you can download them from [device-detection-data](https://gith
 - [51Degrees-LiteV4.1.hash](https://github.com/51Degrees/device-detection-data/blob/main/51Degrees-LiteV4.1.hash)
 - [20000 User Agents.csv](https://github.com/51Degrees/device-detection-data/blob/main/20000%20User%20Agents.csv)
 
+### Software
+
+In order to use device-detection-examples-go the following are required:
+- A C compiler that support C11 or above (Gcc on Linux, Clang on MacOS and MinGW-x64 on Windows)
+- libatomic - which usually come with default Gcc, Clang installation
+
+### Windows
+
+If you are on Windows, make sure that:
+- The path to the `MinGW-x64` `bin` folder is included in the `PATH`. By default, the path should be `C:\msys64\ucrt64\bin`
+- Go environment variable `CGO_ENABLED` is set to `1` 
+```
+go env -w CGO_ENABLED=1
+```
+
 ## Examples
 
 **NOTE**: `device-detection-examples-go` references `device-detection-go` as a dependency in `go.mod`.  No additional actions should be required - the module will be downloaded and built when you do `go run`, `go test`, or `go build` explicitly for any example.  


### PR DESCRIPTION
Fix for the issue https://github.com/51Degrees/device-detection-examples-go/issues/24

 When navigating to /dd/offline_processing and running go run offline_processing.go This error is produced:
github.com/51Degrees/device-detection-examples-go/v4/dd
..\example_base.go:46:28: undefined: dd.PerformanceProfile
..\example_base.go:50:22: undefined: dd.GetFilePath
..\example_base.go:106:29: undefined: dd.PerformanceProfile
..\example_base.go:107:16: undefined: dd.PerformanceProfile
..\example_base.go:110:16: undefined: dd.PerformanceProfile
..\example_base.go:111:7: undefined: dd.Default
..\example_base.go:112:7: undefined: dd.LowMemory
..\example_base.go:113:7: undefined: dd.Balanced
..\example_base.go:114:7: undefined: dd.BalancedTemp
..\example_base.go:115:7: undefined: dd.HighPerformance
..\example_base.go:115:7: too many errors